### PR TITLE
Remove Ktor/coroutines for GraalVM-compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,8 @@ repositories {
 
 dependencies {
     val ktorVersion = "1.1.2"
-    compile("io.ktor:ktor-client-apache:$ktorVersion")
-    compile("io.ktor:ktor-client-gson:$ktorVersion")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.9.8")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
-    testImplementation("io.ktor:ktor-client-mock-jvm:$ktorVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/src/main/kotlin/pullpitok/App.kt
+++ b/src/main/kotlin/pullpitok/App.kt
@@ -1,26 +1,11 @@
 package pullpitok
 
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache.Apache
-import io.ktor.client.features.json.GsonSerializer
-import io.ktor.client.features.json.JsonFeature
-import kotlinx.coroutines.runBlocking
 import pullpitok.github.Action
 import pullpitok.github.Event
 import pullpitok.github.EventClient
 import pullpitok.github.Type
 
-object HttpClientProvider {
-
-    fun httpClient() = HttpClient(Apache) {
-        install(JsonFeature) {
-            serializer = GsonSerializer()
-        }
-    }
-
-}
-
-fun main(args: Array<String>) = runBlocking {
+fun main(args: Array<String>) {
 
     if (!checkArgs(args)) System.exit(0)
     val repo = args[0]
@@ -28,7 +13,7 @@ fun main(args: Array<String>) = runBlocking {
 
     val allEvents = mutableListOf<Event>()
     for (pageNumber in 1..10) {
-        val events = EventClient(httpClient = HttpClientProvider.httpClient())
+        val events = EventClient()
                 .githubEvents(repo, token, page = pageNumber)
         if (events.isNotEmpty()) allEvents.addAll(events)
         else break

--- a/src/test/kotlin/pullpitok/github/EventClentTest.kt
+++ b/src/test/kotlin/pullpitok/github/EventClentTest.kt
@@ -1,74 +1,32 @@
 package pullpitok.github
 
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.MockHttpResponse
-import io.ktor.client.features.json.GsonSerializer
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.http.Headers.Companion.build
-import io.ktor.http.HttpHeaders.ContentType
-import io.ktor.http.HttpStatusCode.Companion.OK
-import kotlinx.coroutines.io.ByteReadChannel
-import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class GithubEventTest {
 
-    val repo = "fakeOrg/fakeRepo"
-    val token = "fakeToken"
-
     @Test
     fun `can return no events with a mocked GitHub API`() {
-        val mockEngine = mockGithubWith("[]")
-        val httpClient = HttpClient(mockEngine) {
-            install(JsonFeature) {
-                serializer = GsonSerializer()
-            }
-        }
-        runBlocking {
-            assertEquals(
-                    emptyList(),
-                    EventClient(httpClient).githubEvents(repo, token, 1))
-        }
+        assertEquals(
+                emptyList(),
+                EventClient().events("[]"))
     }
 
     @Test
     fun `can return several events with a mocked GitHub API`() {
-        val events = loadFile("/events.json")
-        val mockEngine = mockGithubWith(events)
-        val httpClient = HttpClient(mockEngine) {
-            install(JsonFeature) {
-                serializer = GsonSerializer()
-            }
-        }
-        runBlocking {
-            assertEquals(
-                    listOf(
-                            Event(id = "1", type = "PullRequestEvent", actor = Actor("alice"), payload = Payload("opened")),
-                            Event(id = "2.2", type = "PullRequestEvent", actor = Actor("carol"), payload = Payload("opened")),
-                            Event(id = "2", type = "PullRequestEvent", actor = Actor("bob"), payload = Payload("opened")),
-                            Event(id = "2.1", type = "PullRequestEvent", actor = Actor("bob"), payload = Payload("opened")),
-                            Event(id = "3", type = "PullRequestReviewCommentEvent", actor = Actor("carol"), payload = Payload("created")),
-                            Event(id = "3.1", type = "PullRequestReviewCommentEvent", actor = Actor("carol"), payload = Payload("created")),
-                            Event(id = "3.2", type = "PullRequestReviewCommentEvent", actor = Actor("bob"), payload = Payload("created")),
-                            Event(id = "5", type = "PullRequestEvent", actor = Actor("eve"), payload = Payload("closed"))),
-                    EventClient(httpClient).githubEvents(repo, token, 1))
-        }
+        assertEquals(
+                listOf(
+                        Event(id = "1", type = "PullRequestEvent", actor = Actor("alice"), payload = Payload("opened")),
+                        Event(id = "2.2", type = "PullRequestEvent", actor = Actor("carol"), payload = Payload("opened")),
+                        Event(id = "2", type = "PullRequestEvent", actor = Actor("bob"), payload = Payload("opened")),
+                        Event(id = "2.1", type = "PullRequestEvent", actor = Actor("bob"), payload = Payload("opened")),
+                        Event(id = "3", type = "PullRequestReviewCommentEvent", actor = Actor("carol"), payload = Payload("created")),
+                        Event(id = "3.1", type = "PullRequestReviewCommentEvent", actor = Actor("carol"), payload = Payload("created")),
+                        Event(id = "3.2", type = "PullRequestReviewCommentEvent", actor = Actor("bob"), payload = Payload("created")),
+                        Event(id = "5", type = "PullRequestEvent", actor = Actor("eve"), payload = Payload("closed"))),
+                EventClient().events(loadFile("/events.json")))
     }
 
     private fun loadFile(path: String) = GithubEventTest::class.java.getResource(path).readText()
-
-    private fun mockGithubWith(jsonEvents: String): MockEngine = MockEngine {
-        // Verify we called the correct url
-        url.encodedPath
-        assertEquals("https://api.github.com:443/repos/$repo/events?access_token=$token&page=1", "$url")
-        MockHttpResponse(
-                call = call,
-                status = OK,
-                content = ByteReadChannel(jsonEvents),
-                headers = build { set(ContentType, "application/json") }
-        )
-    }
 
 }


### PR DESCRIPTION
Do not use Ktor anymore, so that GraalVM can be used later for generating an
executable.

In fact, Ktor uses Kotlin coroutines, and GraalVM's native-image does not them:
https://github.com/oracle/graal/issues/366