### PR TITLE
Upgrade dependencies to latest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.3.31"
-    id("com.adarshr.test-logger") version "1.6.0"
-    id("se.patrikerdes.use-latest-versions") version "0.2.9"
+    id("org.jetbrains.kotlin.jvm") version "1.3.41"
+    id("se.patrikerdes.use-latest-versions") version "0.2.11"
     id("com.github.ben-manes.versions") version "0.21.0"
-    id("com.github.johnrengelman.shadow") version "5.0.0"
+    id("com.github.johnrengelman.shadow") version "5.1.0"
     application
 }
 
@@ -13,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile("com.fasterxml.jackson.core:jackson-databind:2.9.8")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.9.9")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
-    val kotlinVersion = "1.3.31"
-    id("org.jetbrains.kotlin.jvm").version(kotlinVersion)
-    id("com.adarshr.test-logger").version("1.6.0")
+    id("org.jetbrains.kotlin.jvm") version "1.3.31"
+    id("com.adarshr.test-logger") version "1.6.0"
     id("se.patrikerdes.use-latest-versions") version "0.2.9"
     id("com.github.ben-manes.versions") version "0.21.0"
     id("com.github.johnrengelman.shadow") version "5.0.0"

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -10,7 +10,7 @@ echo "JAR file has been built! ✅"
 echo "Install GraalVM via SDKMAN!:"
 curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-GRAALVM_VERSION=19.0.0-grl
+GRAALVM_VERSION="19.1.0-grl"
 sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null
 sdk use java $GRAALVM_VERSION
 


### PR DESCRIPTION
Executable still works :innocent: : 
```sh
time PULLPITOK_LIBSUNEC=/home/nkosinski/.sdkman/candidates/java/19.1.0-grl/jre/lib/amd64 ./pullpitoK --help
Usage: pullpitoK <repository> <token>

A command line tool to display a summary of GitHub pull requests.

<repository>: a GitHub repository.
    Example: python/peps

<token>: an optional GitHub personal access token
PULLPITOK_LIBSUNEC= ./pullpitoK --help  0.00s user 0.00s system 92% cpu 0.003 total
```