### PR TITLE
Use a coroutine channel to make parallel requests to GitHub

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.3")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }

--- a/src/main/kotlin/pullpitok/App.kt
+++ b/src/main/kotlin/pullpitok/App.kt
@@ -1,42 +1,53 @@
 package pullpitok
 
 import kotlin.system.exitProcess
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import pullpitok.github.Action
 import pullpitok.github.Event
 import pullpitok.github.EventClient
 import pullpitok.github.Type
 
-fun main(args: Array<String>) {
+suspend fun main(args: Array<String>) {
     if (invalidArguments(args)) {
         println(usage)
         exitProcess(0)
     }
     val repos = args[0].split(",")
     val token = args.getOrNull(1)
-    repos
-            .parallelStream()
-            .forEach { displayEvents(it, token) }
+    displayEvents(repos, token)
 }
 
 internal fun invalidArguments(args: Array<String>): Boolean =
         args.size !in (1..2) || args[0] in setOf("", "-h", "--help")
 
-private fun displayEvents(repo: String, token: String?) {
+private suspend fun displayEvents(repos: List<String>, token: String?) = coroutineScope {
+    val channel = Channel<Pair<String, List<Event>>>()
     val allEvents = mutableListOf<Event>()
-    for (pageNumber in 1..10) {
-        val events = EventClient().githubEvents(repo, token, page = pageNumber)
-        if (events.isNotEmpty()) allEvents.addAll(events)
-        else break
+    launch {
+        for (repo in repos) {
+            for (pageNumber in 1..10) {
+                val events = EventClient()
+                        .githubEvents(repo, token, page = pageNumber)
+                if (events.isNotEmpty()) allEvents.addAll(events)
+                else break
+            }
+            channel.send(Pair(repo, allEvents))
+        }
     }
-    val eventsPerAuthor = perAuthor(allEvents)
-    val opened: (Event) -> Boolean = { it.type == Type.PullRequestEvent.name && it.payload.action == Action.opened.name }
-    val commented: (Event) -> Boolean = { it.type == Type.PullRequestReviewCommentEvent.name && it.payload.action == Action.created.name }
-    val closed: (Event) -> Boolean = { it.type == Type.PullRequestEvent.name && it.payload.action == Action.closed.name }
-    println("""pull requests for "$repo" ->
-            opened per author ${counters(eventsPerAuthor, opened)}
-            commented per author ${counters(eventsPerAuthor, commented)}
-            closed per author ${counters(eventsPerAuthor, closed)}
-                """)
+    repeat(repos.size) {
+        val (repo, eventsPerRepo) = channel.receive()
+        val eventsPerAuthor = perAuthor(eventsPerRepo)
+        val opened: (Event) -> Boolean = { it.type == Type.PullRequestEvent.name && it.payload.action == Action.opened.name }
+        val commented: (Event) -> Boolean = { it.type == Type.PullRequestReviewCommentEvent.name && it.payload.action == Action.created.name }
+        val closed: (Event) -> Boolean = { it.type == Type.PullRequestEvent.name && it.payload.action == Action.closed.name }
+        println("""pull requests for "$repo" ->
+        opened per author ${counters(eventsPerAuthor, opened)}
+        commented per author ${counters(eventsPerAuthor, commented)}
+        closed per author ${counters(eventsPerAuthor, closed)}
+        """)
+    }
 }
 
 private fun perAuthor(events: List<Event>): Map<String, List<Event>> = events


### PR DESCRIPTION
See [documentation](https://kotlinlang.org/docs/reference/coroutines/channels.html).

- [x] Fix the `Error: Non-reducible loop` issue (*)
- [ ] Check parallelism for multiple repositories (i.e. `pullpitoK python/peps,haskell/rfcs`)
- [ ] Investigate on errors (see doc about [exception-handling](https://kotlinlang.org/docs/reference/coroutines/exception-handling.html#coroutineexceptionhandler))

(*) : Former `Error: Non-reducible loop` issue (from October 2019) is now solved, Kotlin coroutines were not compatible with `GraalVM 19.2.0.1`:
```
Using java version 19.2.0.1-grl in this shell.
Copying 'libsunec' shared library (Sun Elliptic Curve crypto):
'libsunec' shared library has been copied! ✅
Build executable from JAR via GraalVM:
Downloading: Component catalog from www.graalvm.org
Processing component archive: Native Image
Downloading: Component native-image: Native Image  from github.com
Installing new component: Native Image (org.graalvm.native-image, version 19.2.0.1)
[pullpitoK:23139]    classlist:   2,250.81 ms
[pullpitoK:23139]        (cap):   5,271.10 ms
[pullpitoK:23139]        setup:   6,765.94 ms
[pullpitoK:23139]     analysis:   3,291.25 ms
Error: Non-reducible loop
Detailed message:
Call path from entry point to pullpitok.AppKt$displayEvents$2.invokeSuspend(Object):
	at pullpitok.AppKt$displayEvents$2.invokeSuspend(App.kt)
	at pullpitok.AppKt$displayEvents$2.invoke(App.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:180)
	at pullpitok.AppKt.displayEvents(App.kt:43)
	at pullpitok.AppKt$main$2.invokeSuspend(App.kt:16)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:114)
	at kotlin.coroutines.jvm.internal.RunSuspendKt.runSuspend(RunSuspend.kt:19)
	at pullpitok.AppKt.main(App.kt)
	at com.oracle.svm.core.JavaMainWrapper.runCore(JavaMainWrapper.java:151)
	at com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:186)
	at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)
```
See https://github.com/oracle/graal/issues/366.