### PR TITLE
⬆ Bump GraalVM to 19.2.1

### DIFF
--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -11,7 +11,7 @@ echo "Install GraalVM via SDKMAN!:"
 curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 GRAALVM_VERSION="19.2.1-grl"
-sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null
+sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null || echo "GraalVM $GRAALVM_VERSION already installed."
 sdk use java $GRAALVM_VERSION
 
 echo "Copying 'libsunec' shared library (Sun Elliptic Curve crypto):"

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -10,7 +10,7 @@ echo "JAR file has been built! ✅"
 echo "Install GraalVM via SDKMAN!:"
 curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-GRAALVM_VERSION="19.2.0.1-grl"
+GRAALVM_VERSION="19.2.1-grl"
 sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null
 sdk use java $GRAALVM_VERSION
 


### PR DESCRIPTION
Seems OK (but still getting GraalVM warning 😇 ):
```sh
$ PULLPITOK_LIBSUNEC=/Users/nicolas/.sdkman/candidates/java/19.2.1-grl/jre/lib ./pullpitoK python/peps

Nov 16, 2019 6:23:09 PM com.fasterxml.jackson.databind.ext.Java7Support <clinit>
WARNING: Unable to load JDK7 types (annotations, java.nio.file.Path): no Java7 support added
pull requests for "python/peps" ->
            opened per author
		ewdurbin: 1
		brettcannon: 2
		gvanrossum: 4
		encukou: 1
		m-aciek: 1
		dimitern: 1
		aeros: 1
		di: 1
		samsetegne: 1
		moltob: 1
		pprados: 1
		JelleZijlstra: 1
		maggyero: 1
		wimglenn: 1
		brandtbucher: 1
            commented per author
		brettcannon: 5
		dstufft: 4
		gvanrossum: 1
		Naddiseo: 1
		pradyunsg: 2
		di: 17
		pganssle: 2
		lukpueh: 2
		xavfernandez: 1
		chrahunt: 1
		trishankatdatadog: 1
		JelleZijlstra: 1
		radu-matei: 1
            closed per author
		brettcannon: 10
		gvanrossum: 4
		ilevkivskyi: 2
		ericsnowcurrently: 1
		vstinner: 1
		ambv: 2
		Rosuav: 2
		Yhg1s: 1
```