### PR TITLE
🐛 Analyze public GitHub repositories without authentication token

### DIFF
--- a/src/main/kotlin/pullpitok/App.kt
+++ b/src/main/kotlin/pullpitok/App.kt
@@ -10,7 +10,7 @@ fun main(args: Array<String>) {
     loadLibSunec()
     if (!checkArgs(args)) exitProcess(0)
     val repos = args[0].split(",")
-    val token = args.getOrNull(1) ?: ""
+    val token = args.getOrNull(1)
     repos.parallelStream()
             .forEach { repo ->
                 displayEvents(repo, token)
@@ -38,7 +38,7 @@ A command line tool to display a summary of GitHub pull requests.
             false
         } else true
 
-private fun displayEvents(repo: String, token: String) {
+private fun displayEvents(repo: String, token: String?) {
     val allEvents = mutableListOf<Event>()
     for (pageNumber in 1..10) {
         val events = EventClient().githubEvents(repo, token, page = pageNumber)

--- a/src/main/kotlin/pullpitok/github/EventClient.kt
+++ b/src/main/kotlin/pullpitok/github/EventClient.kt
@@ -11,15 +11,16 @@ class EventClient {
 
     private val client = HttpClient.newBuilder().build()
 
-    fun githubEvents(repo: String, token: String, page: Int): List<Event> {
+    fun githubEvents(repo: String, token: String?, page: Int): List<Event> {
         val url = "https://api.github.com/repos/$repo/events?page=$page"
         val request = HttpRequest.newBuilder()
                 .timeout(Duration.ofSeconds(30))
                 .header("Content-Type", "application/json")
-                .header("Authorization", "token $token")
                 .uri(URI.create(url))
-                .build()
-        val response = client.send(request, BodyHandlers.ofString())
+        if (token != null) {
+                request.header("Authorization", "token $token")
+        }
+        val response = client.send(request.build(), BodyHandlers.ofString())
         if (response.statusCode() != 200) {
             fail("Status code is ${response.statusCode()} for $url")
         }


### PR DESCRIPTION
Before this fix, public GitHub repositories could not be analyzed without a
GitHub token:

  ./gradlew run --args "python/peps"

  Exception in thread "main" java.lang.IllegalArgumentException: Status code is 401 for https://api.github.com/repos/python/peps/events?page=1

This bug is a regression due to commit 69adeb7. 😇