### PR TITLE
⬆ Upgrade libraries to latest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 plugins {
     id("org.jetbrains.kotlin.jvm") version "1.3.72"
     id("se.patrikerdes.use-latest-versions") version "0.2.14"
-    id("com.github.ben-manes.versions") version "0.28.0"
-    id("com.github.johnrengelman.shadow") version "5.2.0"
-    id("com.adarshr.test-logger") version "2.0.0"
-    id("com.diffplug.gradle.spotless") version "4.5.1"
+    id("com.github.ben-manes.versions") version "0.29.0"
+    id("com.github.johnrengelman.shadow") version "6.0.0"
+    id("com.adarshr.test-logger") version "2.1.0"
+    id("com.diffplug.spotless") version "5.1.0"
     application
 }
 
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")


### PR DESCRIPTION
Spotless' group id has changedℹ

   > We have moved from 'com.diffplug.gradle.spotless'
                     to 'com.diffplug.spotless'
     To migrate:
     - Test your build with: id 'com.diffplug.gradle.spotless' version '4.5.1'
     - Fix any deprecation warnings (shouldn't be many / any)
     - Now you can use:      id 'com.diffplug.spotless' version '5.0.0'

     That's all you really need to know, but as always, there are more details in the changelog:
     https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md

     While you're at it, you might want to search for "target '**/".  We used
     to  recommend that in our README, but it's a lot slower than something
     more specific like "target 'src/**".  Also, if you haven't tried them yet,
     take a look at our IDE integration and 'ratchetFrom'.  We've found them
     to be useful, hope you do too.

     If you like the idea behind 'ratchetFrom', you should checkout spotless-changelog
     https://github.com/diffplug/spotless-changelog