### PR TITLE
Remove Gradle 6.7 warning: JavaApplication.setMainClassName

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "1.4.20"
     id("se.patrikerdes.use-latest-versions") version "0.2.15"
     id("com.github.ben-manes.versions") version "0.36.0"
-    id("com.github.johnrengelman.shadow") version "6.1.0"
     id("com.adarshr.test-logger") version "2.1.1"
     id("com.diffplug.spotless") version "5.8.2"
     application
@@ -53,4 +52,15 @@ spotless {
         target("*.gradle.kts")
         ktlint()
     }
+}
+
+tasks.register<Jar>("uberJar") {
+    archiveClassifier.set("all")
+
+    from(sourceSets.main.get().output)
+
+    dependsOn(configurations.runtimeClasspath)
+    from({
+        configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
+    })
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 application {
-    mainClassName = "pullpitok.AppKt"
+    mainClass.set("pullpitok.AppKt")
 }
 
 fun isNonStable(version: String): Boolean {

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -8,7 +8,7 @@ echo "Building JAR file:"
 echo "JAR file has been built! ✅"
 
 echo "Install GraalVM via SDKMAN!:"
-curl --silent "https://get.sdkman.io" | bash || echo 'SDKMAN! already installed'
+curl --silent "https://get.sdkman.io?rcupdate=false" | bash || echo 'SDKMAN! already installed'
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 GRAALVM_VERSION="20.3.0.r11-grl"
 sdkman_auto_answer=true sdk install java $GRAALVM_VERSION > /dev/null || echo "GraalVM $GRAALVM_VERSION already installed."

--- a/generate-executable.sh
+++ b/generate-executable.sh
@@ -4,7 +4,7 @@
 set -e
 
 echo "Building JAR file:"
-./gradlew shadowJar
+./gradlew uberJar
 echo "JAR file has been built! ✅"
 
 echo "Install GraalVM via SDKMAN!:"


### PR DESCRIPTION
Gradle's output no more shows 👋:
```
> Configure project :
The JavaApplication.setMainClassName(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead. See https://docs.gradle.org/6.7.1/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
        at Build_gradle$3.execute(build.gradle.kts:29)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```