### PR TITLE
Remove Gradle message: `'toUpperCase(): String' is deprecated`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 }
 
 fun isNonStable(version: String): Boolean {
-    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
     val regex = "^[0-9,.v-]+(-r)?$".toRegex()
     val isStable = stableKeyword || regex.matches(version)
     return isStable.not()


### PR DESCRIPTION
Before this change, the Gradle build showed this message:

```
w: file:///home/runner/work/pullpitoK/pullpitoK/build.gradle.kts:36:72: 'toUpperCase(): String' is deprecated. Use uppercase() instead.
```