### PR TITLE
Fix CI using `gradle/actions/wrapper-validation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
`gradle/actions/wrapper-validation` replaces `gradle/wrapper-validation-action@v3`: https://github.com/gradle/wrapper-validation-action/blob/main/README.md https://github.com/gradle/actions/blob/main/wrapper-validation/README.md